### PR TITLE
feat: add Plan Mode for Codex sessions

### DIFF
--- a/ACPClient/Sources/ACPClient/ACP/ACPServiceModels.swift
+++ b/ACPClient/Sources/ACPClient/ACP/ACPServiceModels.swift
@@ -7,6 +7,9 @@ public struct ACPInitializationPayload: Sendable {
     public var clientTitle: String?
     public var clientVersion: String
     public var clientCapabilities: [String: ACP.Value]
+    /// Codex app-server capabilities (sent as "capabilities" in the initialize params).
+    /// Separate from clientCapabilities which is ACP-specific.
+    public var capabilities: [String: ACP.Value]
     public var options: [String: ACP.Value]
 
     public init(
@@ -15,6 +18,7 @@ public struct ACPInitializationPayload: Sendable {
         clientVersion: String,
         clientTitle: String? = nil,
         clientCapabilities: [String: ACP.Value] = [:],
+        capabilities: [String: ACP.Value] = [:],
         options: [String: ACP.Value] = [:]
     ) {
         self.protocolVersion = protocolVersion
@@ -22,6 +26,7 @@ public struct ACPInitializationPayload: Sendable {
         self.clientTitle = clientTitle
         self.clientVersion = clientVersion
         self.clientCapabilities = clientCapabilities
+        self.capabilities = capabilities
         self.options = options
     }
 
@@ -37,6 +42,9 @@ public struct ACPInitializationPayload: Sendable {
             "clientInfo": .object(clientInfo.compactMapValues { $0 }),
             "clientCapabilities": .object(clientCapabilities)
         ]
+        if !capabilities.isEmpty {
+            object["capabilities"] = .object(capabilities)
+        }
         if !options.isEmpty {
             object["options"] = .object(options)
         }

--- a/Agmente/ACPSessionViewModel.swift
+++ b/Agmente/ACPSessionViewModel.swift
@@ -81,6 +81,7 @@ final class ACPSessionViewModel: ObservableObject {
     private var sessionModeCache: [UUID: [String: String]] = [:] // serverId -> sessionId -> currentModeId
     private var pendingPermissionRequests: [ACP.ID: (sessionId: String, toolCallId: String?)] = [:]
     private var pendingApprovalRequests: [JSONRPCID: String?] = [:]
+    @Published var activeUserInputRequest: PendingUserInputRequest?
     private var sessionCommandsCache: [UUID: [String: [SessionCommand]]] = [:] // serverId -> sessionId -> available commands
     // Note: chatCache and stopReasonCache moved to AppViewModel (accessed via cacheDelegate)
 
@@ -736,6 +737,26 @@ final class ACPSessionViewModel: ObservableObject {
         saveChatState()
     }
 
+    /// Finalizes a plan segment with the complete text (used on item/completed).
+    func completePlanItem(id: String?, text: String) {
+        let index = ensureStreamingAssistantMessage()
+        // Replace existing plan segment or append new one
+        if let lastIndex = chatMessages[index].segments.indices.last,
+           chatMessages[index].segments[lastIndex].kind == .plan {
+            chatMessages[index].segments[lastIndex].text = text
+        } else {
+            chatMessages[index].segments.append(AssistantSegment(kind: .plan, text: text))
+        }
+        rebuildAssistantContent(at: index)
+        saveChatState()
+    }
+
+    /// Stores a pending user input request from the server, presented as a sheet.
+    func addUserInputRequest(requestId: JSONRPCID, questions: [UserInputQuestion]) {
+        let request = PendingUserInputRequest(requestId: requestId, questions: questions)
+        activeUserInputRequest = request
+    }
+
     func upsertToolCallFromAppServer(
         toolCallId: String?,
         title: String?,
@@ -839,6 +860,8 @@ final class ACPSessionViewModel: ObservableObject {
                     return "Tool call: \(displayContent) (\(status))"
                 }
                 return "Tool call: \(displayContent)"
+            case .plan:
+                return segment.text
             }
         }
 

--- a/Agmente/CodexServerViewModel.swift
+++ b/Agmente/CodexServerViewModel.swift
@@ -97,6 +97,10 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
     @Published private(set) var availableSkills: [AppServerSkill] = []
     @Published var enabledSkillNames: Set<String> = []
 
+    // MARK: - Plan Mode (Codex-specific)
+
+    @Published var isPlanModeEnabled: Bool = false
+
     // MARK: - Private State
 
     private let connectionManager: ACPClientManager
@@ -240,6 +244,7 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
             case commandExecution(id: String?, command: String?, output: String?)
             case fileChange(id: String?, path: String?, changeType: String?, diff: String?)
             case toolCall(id: String?, title: String, kind: String?, status: String?, output: String?)
+            case plan(id: String?, text: String)
             case unknown(type: String)
         }
 
@@ -583,6 +588,13 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
                         AssistantSegment(kind: .toolCall, text: displayTitle, toolCall: toolCall),
                     ])
 
+                case .plan(_, let text):
+                    if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        viewModel.addAssistantSegments([
+                            AssistantSegment(kind: .plan, text: text),
+                        ])
+                    }
+
                 case .unknown(let type):
                     unknownItems += 1
                     appendClosure("Unknown Codex item type: \(type)")
@@ -729,7 +741,8 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
                     text: prompt,
                     model: selectedModelId,
                     effort: selectedEffort,
-                    skills: skillNames
+                    skills: skillNames,
+                    isPlanMode: isPlanModeEnabled
                 )
                 bumpSessionTimestamp(sessionId: sessionId)
                 updateSessionTitleIfNeeded(with: prompt)
@@ -1002,7 +1015,7 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
         return id
     }
 
-    private func startTurn(threadId: String, text: String, model: String?, effort: String?, skills: [String]?) async throws {
+    private func startTurn(threadId: String, text: String, model: String?, effort: String?, skills: [String]?, isPlanMode: Bool = false) async throws {
         let input: JSONValue = .array([
             .object([
                 "type": .string("text"),
@@ -1018,6 +1031,12 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
         if let skills, !skills.isEmpty {
             params["skills"] = .array(skills.map { .string($0) })
         }
+        var settings: [String: JSONValue] = [:]
+        if let model { settings["model"] = .string(model) }
+        params["collaborationMode"] = .object([
+            "mode": .string(isPlanMode ? "plan" : "default"),
+            "settings": .object(settings),
+        ])
 
         let response = try await callCodex(method: "turn/start", params: .object(params))
         activeThreadId = threadId
@@ -1101,6 +1120,65 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
         }
     }
 
+    // MARK: - User Input Requests (Plan Mode)
+
+    private func handleRequestUserInput(_ request: JSONRPCRequest) {
+        guard let params = request.params?.objectValue else { return }
+        guard case .array(let questionsArray) = params["questions"] else { return }
+
+        var questions: [UserInputQuestion] = []
+        for q in questionsArray {
+            guard let qObj = q.objectValue else { continue }
+            let questionId = qObj["id"]?.stringValue ?? UUID().uuidString
+            let header = qObj["header"]?.stringValue ?? ""
+            let text = qObj["question"]?.stringValue ?? qObj["text"]?.stringValue ?? ""
+            let multiSelect = qObj["multiSelect"]?.boolValue ?? false
+            var options: [UserInputOption] = []
+            if case .array(let optionsArray) = qObj["options"] {
+                for opt in optionsArray {
+                    if let optObj = opt.objectValue {
+                        let label = optObj["label"]?.stringValue ?? ""
+                        let description = optObj["description"]?.stringValue
+                        let isOther = optObj["isOther"]?.boolValue ?? false
+                        let isSecret = optObj["isSecret"]?.boolValue ?? false
+                        options.append(UserInputOption(label: label, description: description, isOther: isOther, isSecret: isSecret))
+                    }
+                }
+            }
+            questions.append(UserInputQuestion(
+                id: questionId,
+                header: header,
+                text: text,
+                options: options,
+                multiSelect: multiSelect
+            ))
+        }
+
+        guard !questions.isEmpty else { return }
+        currentSessionViewModel?.addUserInputRequest(
+            requestId: request.id,
+            questions: questions
+        )
+    }
+
+    func respondToUserInputRequest(requestId: JSONRPCID, answers: [String: [String]]) {
+        Task { @MainActor in
+            var answersPayload: [String: JSONValue] = [:]
+            for (questionId, selectedAnswers) in answers {
+                answersPayload[questionId] = .object([
+                    "answers": .array(selectedAnswers.map { .string($0) })
+                ])
+            }
+            let payload: [String: JSONValue] = ["answers": .object(answersPayload)]
+            let response = JSONRPCMessage.response(JSONRPCResponse(id: requestId, result: .object(payload)))
+            do {
+                try await service?.sendMessage(response)
+            } catch {
+                // Best-effort.
+            }
+        }
+    }
+
     // MARK: - Codex Message Handling
 
     /// Handle Codex-specific messages (notifications from the backend).
@@ -1132,6 +1210,15 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
                 }
                 if let delta = params["delta"]?.stringValue {
                     currentSessionViewModel?.appendAssistantText(delta, kind: .message)
+                }
+            case "item/plan/delta":
+                if let activeTurnId,
+                   let turnId = params["turnId"]?.stringValue,
+                   turnId != activeTurnId {
+                    return
+                }
+                if let delta = params["delta"]?.stringValue {
+                    currentSessionViewModel?.appendAssistantText(delta, kind: .plan)
                 }
             case "item/started":
                 let turnId = params["turnId"]?.stringValue
@@ -1193,6 +1280,8 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
             case "item/commandExecution/requestApproval", "item/fileChange/requestApproval":
                 // Approval requests are handled by handleApprovalRequest from AppViewModel.
                 break
+            case "item/tool/requestUserInput":
+                handleRequestUserInput(request)
             default:
                 break
             }
@@ -1358,6 +1447,12 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
                         output: output
                     )
                 }
+            }
+
+        case .plan(let itemId, let text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                viewModel.completePlanItem(id: itemId, text: trimmed)
             }
 
         case .agentMessage, .userMessage, .unknown:
@@ -1580,6 +1675,9 @@ final class CodexServerViewModel: ObservableObject, Identifiable, ServerViewMode
             return .fileChange(id: itemId, path: path, changeType: changeType, diff: diff)
         case "toolcall", "tool", "functioncall", "function":
             return parseGenericToolCall(id: itemId, type: type, object: obj)
+        case "plan":
+            let text = obj["text"]?.stringValue ?? ""
+            return .plan(id: itemId, text: text)
         default:
             if normalizedType.contains("reason") || normalizedType.contains("thought") || normalizedType.contains("analysis") {
                 let text = extractReasoningText(from: obj)

--- a/Agmente/PlanModeViews.swift
+++ b/Agmente/PlanModeViews.swift
@@ -1,0 +1,391 @@
+import SwiftUI
+import ACPClient
+
+// MARK: - Data Models
+
+struct UserInputOption: Equatable, Identifiable {
+    let id = UUID()
+    let label: String
+    let description: String?
+    let isOther: Bool
+    let isSecret: Bool
+}
+
+struct UserInputQuestion: Equatable, Identifiable {
+    let id: String
+    let header: String
+    let text: String
+    let options: [UserInputOption]
+    let multiSelect: Bool
+}
+
+struct PendingUserInputRequest: Equatable, Identifiable {
+    var id: String {
+        switch requestId {
+        case .string(let s): return s
+        case .int(let i): return String(i)
+        }
+    }
+    let requestId: JSONRPCID
+    let questions: [UserInputQuestion]
+    var isSubmitted: Bool = false
+}
+
+// MARK: - Proposed Plan Card
+
+struct ProposedPlanCard: View {
+    let content: String
+    let isStreaming: Bool
+    let onImplement: () -> Void
+    let onContinuePlanning: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Header
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.footnote.weight(.semibold))
+                Text("Proposed Plan")
+                    .font(.footnote.weight(.semibold))
+            }
+            .foregroundStyle(.blue)
+
+            // Plan content
+            if !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                MarkdownText(content: content)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if isStreaming {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Planning...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Action buttons (shown when not streaming)
+            if !isStreaming && !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                HStack(spacing: 10) {
+                    Button(action: onImplement) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "hammer")
+                                .font(.caption.weight(.semibold))
+                            Text("Implement this plan")
+                                .font(.footnote.weight(.medium))
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Color.blue)
+                        .foregroundStyle(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: onContinuePlanning) {
+                        Text("Continue planning")
+                            .font(.footnote.weight(.medium))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(Color(.systemGray5))
+                            .foregroundStyle(.secondary)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 10)
+        .background(Color.blue.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - User Input Questions Sheet
+
+/// A sheet that presents plan-mode questions one at a time with swipe navigation.
+/// Automatically dismisses after the user submits their answers.
+struct UserInputQuestionsSheet: View {
+    let request: PendingUserInputRequest
+    let onSubmit: (JSONRPCID, [String: [String]]) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var currentPage: Int = 0
+    @State private var selections: [String: Set<String>] = [:]
+    @State private var otherTexts: [String: String] = [:]
+
+    private var questions: [UserInputQuestion] { request.questions }
+    private var isLastPage: Bool { currentPage >= questions.count - 1 }
+    private var hasAnySelection: Bool {
+        for question in questions {
+            if let selected = selections[question.id], !selected.isEmpty { return true }
+            if let text = otherTexts[question.id], !text.isEmpty { return true }
+        }
+        return false
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Page indicator
+                if questions.count > 1 {
+                    pageIndicator
+                        .padding(.top, 8)
+                }
+
+                // Swipeable question pages
+                TabView(selection: $currentPage) {
+                    ForEach(Array(questions.enumerated()), id: \.element.id) { index, question in
+                        questionPage(for: question)
+                            .tag(index)
+                    }
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .animation(.easeInOut(duration: 0.25), value: currentPage)
+
+                // Bottom bar with navigation and submit
+                bottomBar
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 16)
+            }
+            .navigationTitle("Plan Mode Question")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Skip") {
+                        // Submit empty answers to unblock the server
+                        onSubmit(request.requestId, [:])
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - Page Indicator
+
+    private var pageIndicator: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<questions.count, id: \.self) { index in
+                Circle()
+                    .fill(index == currentPage ? Color.blue : Color(.systemGray4))
+                    .frame(width: 7, height: 7)
+                    .onTapGesture { currentPage = index }
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Question Page
+
+    private func questionPage(for question: UserInputQuestion) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                // Header badge
+                if !question.header.isEmpty {
+                    Text(question.header)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(Color.orange)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+
+                // Question text
+                Text(question.text)
+                    .font(.body)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if question.multiSelect {
+                    Text("Select all that apply")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                // Options
+                VStack(spacing: 8) {
+                    ForEach(question.options) { option in
+                        if option.isOther {
+                            otherInputRow(for: question, option: option)
+                        } else {
+                            optionRow(for: question, option: option)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .padding(.bottom, 80) // Space for bottom bar
+        }
+    }
+
+    // MARK: - Option Row
+
+    private func optionRow(for question: UserInputQuestion, option: UserInputOption) -> some View {
+        let isSelected = selections[question.id]?.contains(option.label) ?? false
+
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                var current = selections[question.id] ?? []
+                if question.multiSelect {
+                    if current.contains(option.label) {
+                        current.remove(option.label)
+                    } else {
+                        current.insert(option.label)
+                    }
+                } else {
+                    current = [option.label]
+                }
+                selections[question.id] = current
+            }
+        } label: {
+            HStack(spacing: 12) {
+                // Selection indicator
+                Image(systemName: isSelected
+                    ? (question.multiSelect ? "checkmark.square.fill" : "largecircle.fill.circle")
+                    : (question.multiSelect ? "square" : "circle"))
+                    .foregroundStyle(isSelected ? .blue : .secondary)
+                    .font(.title3)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.label)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.primary)
+                    if let desc = option.description, !desc.isEmpty {
+                        Text(desc)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(isSelected ? Color.blue.opacity(0.08) : Color(.systemGray6))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? Color.blue.opacity(0.3) : Color(.systemGray4).opacity(0.5), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Other Input Row
+
+    private func otherInputRow(for question: UserInputQuestion, option: UserInputOption) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(option.label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if option.isSecret {
+                SecureField("Enter value...", text: Binding(
+                    get: { otherTexts[question.id] ?? "" },
+                    set: { otherTexts[question.id] = $0 }
+                ))
+                .textFieldStyle(.roundedBorder)
+            } else {
+                TextField("Type your answer...", text: Binding(
+                    get: { otherTexts[question.id] ?? "" },
+                    set: { otherTexts[question.id] = $0 }
+                ))
+                .textFieldStyle(.roundedBorder)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: - Bottom Bar
+
+    private var bottomBar: some View {
+        HStack {
+            // Previous button
+            if currentPage > 0 {
+                Button {
+                    withAnimation { currentPage -= 1 }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                            .font(.caption.weight(.semibold))
+                        Text("Previous")
+                            .font(.footnote.weight(.medium))
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(Color(.systemGray5))
+                    .foregroundStyle(.primary)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+
+            if isLastPage || questions.count == 1 {
+                // Submit button
+                Button(action: submitAnswers) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "paperplane.fill")
+                            .font(.caption.weight(.semibold))
+                        Text("Submit")
+                            .font(.footnote.weight(.medium))
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(hasAnySelection ? Color.blue : Color.blue.opacity(0.4))
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+            } else {
+                // Next button
+                Button {
+                    withAnimation { currentPage += 1 }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("Next")
+                            .font(.footnote.weight(.medium))
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(Color.blue)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Submit
+
+    private func submitAnswers() {
+        var answers: [String: [String]] = [:]
+        for question in questions {
+            var selected = Array(selections[question.id] ?? [])
+            if let otherText = otherTexts[question.id], !otherText.isEmpty {
+                selected.append(otherText)
+            }
+            if !selected.isEmpty {
+                answers[question.id] = selected
+            }
+        }
+        onSubmit(request.requestId, answers)
+        dismiss()
+    }
+}

--- a/Agmente/SessionDetailView.swift
+++ b/Agmente/SessionDetailView.swift
@@ -695,6 +695,16 @@ private extension SessionDetailView {
                     }
                 case .toolCall(let segment):
                     toolCallBubble(segment: segment, isStreaming: message.isStreaming && lastIndex == index)
+                case .plan(let segment):
+                    if !segment.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        MarkdownText(content: segment.text)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                            .background(Color.blue.opacity(0.08))
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
                 }
             }
 

--- a/Agmente/SessionSupplementalViews.swift
+++ b/Agmente/SessionSupplementalViews.swift
@@ -136,10 +136,11 @@ enum DisplaySegment: Identifiable {
     case message(AssistantSegment)
     case toolCall(AssistantSegment)
     case thoughtGroup(ThoughtGroup)
+    case plan(AssistantSegment)
 
     var id: UUID {
         switch self {
-        case .message(let segment), .toolCall(let segment):
+        case .message(let segment), .toolCall(let segment), .plan(let segment):
             return segment.id
         case .thoughtGroup(let group):
             return group.id
@@ -178,6 +179,9 @@ extension Array where Element == AssistantSegment {
             case .message:
                 flushGroup()
                 grouped.append(.message(segment))
+            case .plan:
+                flushGroup()
+                grouped.append(.plan(segment))
             }
         }
 


### PR DESCRIPTION
- Add isPlanModeEnabled toggle on CodexServerViewModel with UI button
- New PlanModeViews.swift: ProposedPlanCard, UserInputQuestionsSheet, and supporting data models (UserInputQuestion, PendingUserInputRequest)
- Always send collaborationMode in turn/start (plan or default) so "Implement this plan" correctly switches the server out of plan mode
- Add capabilities field to ACPInitializationPayload for experimentalApi
- Handle item/plan/delta and item/tool/requestUserInput notifications
- Add .plan segment kind to AssistantSegment and DisplaySegment pipeline