### PR TITLE
Add archive support for codex app-server sessions

### DIFF
--- a/Agmente/AppViewModel.swift
+++ b/Agmente/AppViewModel.swift
@@ -937,6 +937,12 @@ final class AppViewModel: ObservableObject, ACPClientManagerDelegate, ACPSession
         serverViewModel.deleteSession(sessionId)
     }
 
+    /// Archive a session on the server (Codex app-server only).
+    func archiveSession(_ sessionId: String) {
+        guard let codexViewModel = selectedCodexServerViewModel else { return }
+        codexViewModel.archiveSession(sessionId)
+    }
+
     private func persistActiveServerConfig() {
         guard let serverId = selectedServerId,
               let index = servers.firstIndex(where: { $0.id == serverId }) else { return }
@@ -1043,6 +1049,11 @@ final class AppViewModel: ObservableObject, ACPClientManagerDelegate, ACPSession
     var canDeleteSessionsLocally: Bool {
         guard let serverId = selectedServerId else { return false }
         return sessionListSupportFlag(for: serverId) == false
+    }
+
+    /// Whether the selected server supports archiving sessions (Codex app-server only).
+    var canArchiveSessions: Bool {
+        selectedCodexServerViewModel != nil
     }
 
     private func sortSessionSummaries(_ summaries: [SessionSummary]) -> [SessionSummary] {

--- a/Agmente/CodexSessionDetailView.swift
+++ b/Agmente/CodexSessionDetailView.swift
@@ -11,6 +11,7 @@ struct CodexSessionDetailView: View {
     @FocusState private var isTextEditorFocused: Bool
     @State private var textEditorWidth: CGFloat = 0
     @State private var showDeleteSessionConfirm = false
+    @State private var showArchiveSessionConfirm = false
     @State private var expandedThoughts: Set<UUID> = []
     @State private var fileChangesReviewPayload: FileChangesReviewPayload?
     @State private var showUndoUnavailableAlert = false
@@ -123,13 +124,23 @@ struct CodexSessionDetailView: View {
             }
         }
         .toolbar {
-            if model.canDeleteSessionsLocally, !serverViewModel.sessionId.isEmpty {
+            if !serverViewModel.sessionId.isEmpty,
+               model.canArchiveSessions || model.canDeleteSessionsLocally {
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {
-                        Button(role: .destructive) {
-                            showDeleteSessionConfirm = true
-                        } label: {
-                            Label("Delete Session", systemImage: "trash")
+                        if model.canArchiveSessions {
+                            Button(role: .destructive) {
+                                showArchiveSessionConfirm = true
+                            } label: {
+                                Label("Archive Session", systemImage: "archivebox")
+                            }
+                        }
+                        if model.canDeleteSessionsLocally {
+                            Button(role: .destructive) {
+                                showDeleteSessionConfirm = true
+                            } label: {
+                                Label("Delete Session", systemImage: "trash")
+                            }
                         }
                     } label: {
                         Image(systemName: "ellipsis")
@@ -150,6 +161,20 @@ struct CodexSessionDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This removes the session and its cached chat history from this device.")
+        }
+        .confirmationDialog(
+            "Archive Session?",
+            isPresented: $showArchiveSessionConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Archive Session", role: .destructive) {
+                let idToArchive = serverViewModel.sessionId
+                guard !idToArchive.isEmpty else { return }
+                model.archiveSession(idToArchive)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This archives the session on the server. It will no longer appear in your session list.")
         }
         .alert("Undo not available", isPresented: $showUndoUnavailableAlert) {
             Button("OK", role: .cancel) {}

--- a/Agmente/ServerViewModel.swift
+++ b/Agmente/ServerViewModel.swift
@@ -847,6 +847,11 @@ final class ServerViewModel: ObservableObject, Identifiable, ServerViewModelProt
         storage?.deleteSession(sessionId: sessionId, forServerId: id)
     }
 
+    /// Archive a session. ACP protocol does not support archive — this is a no-op.
+    func archiveSession(_ sessionId: String) {
+        // ACP protocol has no archive operation; use deleteSession for local removal.
+    }
+
     /// Abort a pending session creation and clean up placeholder UI state.
     private func failPendingSessionCreation(placeholderId: String, errorMessage: String) {
         guard pendingLocalSessions.contains(placeholderId) else { return }

--- a/Agmente/ServerViewModelProtocol.swift
+++ b/Agmente/ServerViewModelProtocol.swift
@@ -54,6 +54,9 @@ protocol ServerViewModelProtocol: ObservableObject, Identifiable where ID == UUI
     /// Delete a session.
     func deleteSession(_ sessionId: String)
 
+    /// Archive a session (Codex app-server only; no-op for ACP).
+    func archiveSession(_ sessionId: String)
+
     /// Set the active session.
     func setActiveSession(_ id: String, cwd: String?, modes: ACPModesInfo?)
 


### PR DESCRIPTION
Wire up the existing thread/archive RPC method to the app layer and UI.
The transport layer (AppServerService.archiveThread) already existed but
was unused. This adds:

- archiveSession() to ServerViewModelProtocol
- CodexServerViewModel.archiveSession() calling thread/archive RPC
- archiveThread() private RPC helper in CodexServerViewModel
- No-op stub in ServerViewModel (ACP has no archive)
- archiveSession() delegation in AppViewModel
- canArchiveSessions computed property in AppViewModel
- Archive Session button + confirmation dialog in CodexSessionDetailView

https://claude.ai/code/session_01ReFNb97MSdJC8U4pfkeVrE