### PR TITLE
Add external repo path configuration and documentation updates

### DIFF
--- a/.agmente.paths.example
+++ b/.agmente.paths.example
@@ -1,0 +1,2 @@
+AGMENTE_ACP_REPO=/absolute/path/to/agent-client-protocol
+AGMENTE_CODEX_REPO=/absolute/path/to/codex

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ AppServerClient/.build
 ACPClient/.build
 *.env
 *.env.*
+.agmente.paths
 **/xcuserdata/
 **/*.xcbkptlist
 **/*.xcuserstate

--- a/ACPClient/AGENTS.md
+++ b/ACPClient/AGENTS.md
@@ -3,6 +3,10 @@
 ## Scope
 Typed ACP transport/service package used by the iOS app.
 
+## External Repo Paths
+- Read `.agmente.paths` (from repo root) before cross-checking ACP upstream docs/spec.
+- ACP upstream reference root: `AGMENTE_ACP_REPO/docs`.
+
 ## Architecture Model
 - Transport concerns, request orchestration, and ACP parsing are separated layers.
 - Public service APIs should remain typed and hide wire-format details from callers.

--- a/Agents.md
+++ b/Agents.md
@@ -32,6 +32,14 @@
   - required tests,
   - compatibility constraints with ACP/Codex and any migration behavior.
 
+## Local External Repo Config
+- Create `.agmente.paths` from `.agmente.paths.example` only if it does not already exist; otherwise keep your existing file and update keys as needed.
+- `.agmente.paths` is local-only and gitignored.
+- Use `.agmente.paths` as the single local path registry for ACP/Codex upstream checkouts.
+- Required variables:
+  - `AGMENTE_ACP_REPO`: local `agent-client-protocol` checkout.
+  - `AGMENTE_CODEX_REPO`: local `codex` checkout (must contain `codex-rs`).
+
 ## What this app does
 - Connect to an Agent Client Protocol (ACP) server over WebSocket.
 - Connect to an OpenAI Codex app-server over WebSocket.
@@ -71,7 +79,8 @@
 # If codex is installed in PATH
 codex app-server --listen ws://127.0.0.1:8788
 
-# Or from Codex source checkout
+# Or from Codex source checkout (read `AGMENTE_CODEX_REPO` from `.agmente.paths`)
+cd <AGMENTE_CODEX_REPO>/codex-rs
 cargo run -p codex-cli -- app-server --listen ws://127.0.0.1:8788
 ```
 
@@ -258,6 +267,7 @@ You can get the simulator UUID from `xcrun simctl list devices` or from the `lis
 
 ## ACPClient reference
 - The iOS app uses the local `ACPClient` Swift package (`Agmente/ACPClient`) to speak ACP over WebSocket.
+- ACP protocol/spec upstream reference checkout: `AGMENTE_ACP_REPO/docs` (especially `AGMENTE_ACP_REPO/docs/protocol` and `AGMENTE_ACP_REPO/docs/schema`).
 - Key types: `ACPClientConfiguration` (endpoint, auth token provider, ping), `ACPClient` (connect/send), and delegate callbacks for state and messages.
 - RPC entry points used in the app: `initialize`, `session/new`, `session/prompt`, `session/cancel`, and optional `session/list`.
 - If you extend the client, keep new RPC methods consistent with ACP JSON-RPC envelopes and add handlers to `ACPViewModel`.
@@ -270,10 +280,10 @@ You can get the simulator UUID from `xcrun simctl list devices` or from the `lis
 ---
 
 ## Codex app-server reference (local source)
-- App-server implementation: `<codex-repo>/codex-rs/app-server`
-  - README for protocol flow and examples: `<codex-repo>/codex-rs/app-server/README.md`
-- Protocol types/schema: `<codex-repo>/codex-rs/app-server-protocol`
-  - v2 protocol definitions (Thread/Turn/Item): `<codex-repo>/codex-rs/app-server-protocol/src/protocol/v2.rs`
+- App-server implementation: `AGMENTE_CODEX_REPO/codex-rs/app-server`
+  - README for protocol flow and examples: `AGMENTE_CODEX_REPO/codex-rs/app-server/README.md`
+- Protocol types/schema: `AGMENTE_CODEX_REPO/codex-rs/app-server-protocol`
+  - v2 protocol definitions (Thread/Turn/Item): `AGMENTE_CODEX_REPO/codex-rs/app-server-protocol/src/protocol/v2.rs`
 - Schema generation (from installed Codex CLI):
   - `codex app-server generate-ts --out DIR`
   - `codex app-server generate-json-schema --out DIR`

--- a/Agmente/AGENTS.md
+++ b/Agmente/AGENTS.md
@@ -6,6 +6,10 @@ SwiftUI app layer and protocol routing logic:
 - Session/thread UI state
 - ACP vs Codex view model selection
 
+## External Repo Paths
+- For upstream ACP/Codex source checks, read `.agmente.paths` from repo root.
+- Use `AGMENTE_ACP_REPO` and `AGMENTE_CODEX_REPO` entries instead of machine-specific absolute paths.
+
 ## Architecture Model
 - The app has a single coordinator that owns per-server runtime state.
 - Each server runtime follows one protocol mode at a time (ACP or Codex).

--- a/AgmenteTests/AGENTS.md
+++ b/AgmenteTests/AGENTS.md
@@ -3,6 +3,10 @@
 ## Scope
 Unit/integration-style tests for app-layer view models and persistence.
 
+## External Repo Paths
+- If a test change requires checking ACP/Codex upstream behavior, read `.agmente.paths` from repo root.
+- Use `AGMENTE_ACP_REPO` and `AGMENTE_CODEX_REPO` for local external checkout paths.
+
 ## Test Layers
 - Protocol routing and view-model synchronization tests.
 - ACP-specific session behavior tests.

--- a/AgmenteUITests/AGENTS.md
+++ b/AgmenteUITests/AGENTS.md
@@ -3,6 +3,10 @@
 ## Scope
 Simulator-driven UI tests, including opt-in Codex local E2E.
 
+## External Repo Paths
+- Use root `.agmente.paths` for machine-local ACP/Codex checkout locations when debugging upstream compatibility.
+- Read it as the source of truth; do not hard-code local absolute paths.
+
 ## Coverage Goals
 - Add-server flows for ACP and Codex.
 - Connect/initialize/session lifecycle UX.

--- a/AppServerClient/AGENTS.md
+++ b/AppServerClient/AGENTS.md
@@ -3,6 +3,10 @@
 ## Scope
 Typed Codex app-server transport/service package used by the iOS app.
 
+## External Repo Paths
+- Read `.agmente.paths` (from repo root) before cross-checking Codex app-server upstream source.
+- Codex upstream reference root: `AGMENTE_CODEX_REPO/codex-rs`.
+
 ## Architecture Model
 - Transport and request orchestration are separated from protocol payload parsing.
 - Service APIs should remain typed and avoid leaking raw JSON-RPC details to callers.
@@ -35,7 +39,7 @@ Maintenance guardrails:
 - Keep `includeTurns: true` on read-based hydration paths.
 - Remember that `persistExtendedHistory` is not backfilled for old sessions.
 
-See `/Users/lvpeng/Code/Agmente-oss/AppServerClient/codex-thread-hydration.md` for the expanded maintenance checklist and regression scenarios.
+See `AppServerClient/codex-thread-hydration.md` for the expanded maintenance checklist and regression scenarios.
 
 ## Extension Pattern
 When adding app-server method support:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@ This file is the entrypoint for cloud/Claude coding agents. Use it with `Agents.
    - `AgmenteTests/AGENTS.md`
    - `AgmenteUITests/AGENTS.md`
 
+## Local Path Config
+- Use root `.agmente.paths` for machine-local external repo paths.
+- Required vars: `AGMENTE_ACP_REPO`, `AGMENTE_CODEX_REPO`.
+- Read this file when running upstream-spec/source checks.
+
 ## Core Architecture
 - Agmente supports two protocol modes: ACP and Codex app-server.
 - Protocol is detected after `initialize` and routed to protocol-specific view models.


### PR DESCRIPTION
- Introduced `.agmente.paths` for local ACP/Codex repository paths.
- Updated various documentation files to reference `.agmente.paths` for upstream checks.
- Ensured `.agmente.paths` is gitignored to maintain local configurations.